### PR TITLE
Add Slack Compose linting

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,15 +23,23 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
     buildFeatures {
-        compose =true
+        compose = true
         buildConfig = true
     }
     buildTypes {
         debug {
-            buildConfigField("String", "BASE_URL", "\"https://score-dev.cornellappdev.com/graphql\"")
+            buildConfigField(
+                "String",
+                "BASE_URL",
+                "\"https://score-dev.cornellappdev.com/graphql\""
+            )
         }
         release {
-            buildConfigField("String", "BASE_URL", "\"https://score-dev.cornellappdev.com/graphql\"")
+            buildConfigField(
+                "String",
+                "BASE_URL",
+                "\"https://score-dev.cornellappdev.com/graphql\""
+            )
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
@@ -84,6 +92,7 @@ dependencies {
     implementation(libs.apollo.runtime)
     implementation("io.coil-kt.coil3:coil-compose:3.1.0")
     implementation("io.coil-kt.coil3:coil-network-okhttp:3.1.0")
+    lintChecks(libs.compose.lint.checks)
 }
 
 apollo {

--- a/app/src/main/java/com/cornellappdev/score/components/EmptyStateMessage.kt
+++ b/app/src/main/java/com/cornellappdev/score/components/EmptyStateMessage.kt
@@ -52,7 +52,7 @@ fun EmptyStateMessage(modifier: Modifier = Modifier) {
 
 @Preview
 @Composable
-fun PreviewEmptyStateMessage() {
+private fun PreviewEmptyStateMessage() {
     Box(modifier = Modifier.background(Color.White)) {
         EmptyStateMessage()
     }

--- a/app/src/main/java/com/cornellappdev/score/components/GameScoreHeader.kt
+++ b/app/src/main/java/com/cornellappdev/score/components/GameScoreHeader.kt
@@ -94,7 +94,7 @@ fun GameScoreHeader(
 
 @Preview
 @Composable
-fun GameScoreHeaderPreview() {
+private fun GameScoreHeaderPreview() {
     GameScoreHeader(
         leftTeamLogo = painterResource(R.drawable.cornell_logo),
         rightTeamLogo = painterResource(R.drawable.penn_logo),

--- a/app/src/main/java/com/cornellappdev/score/components/ScoreBox.kt
+++ b/app/src/main/java/com/cornellappdev/score/components/ScoreBox.kt
@@ -125,12 +125,12 @@ fun TeamScoreRow(teamScore: TeamScore, totalTextColor: Color) {
 
 @Preview(showBackground = true)
 @Composable
-fun PreviewBoxScore() {
+private fun PreviewBoxScore() {
     BoxScore(gameData = gameData)
 }
 
 @Preview(showBackground = true)
 @Composable
-fun PreviewBoxScoreEmpty() {
+private fun PreviewBoxScoreEmpty() {
     BoxScore(gameData = emptyGameData())
 }

--- a/app/src/main/java/com/cornellappdev/score/components/ScoreSummary.kt
+++ b/app/src/main/java/com/cornellappdev/score/components/ScoreSummary.kt
@@ -1,9 +1,13 @@
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.*
+import androidx.compose.material3.Divider
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -102,6 +106,6 @@ fun ScoreEventItem(event: ScoreEvent) {
 
 @Preview(showBackground = true)
 @Composable
-fun PreviewScoringSummary() {
+private fun PreviewScoringSummary() {
     ScoringSummary(scoreEvents = scoreEvents1)
 }

--- a/app/src/main/java/com/cornellappdev/score/components/SportCard.kt
+++ b/app/src/main/java/com/cornellappdev/score/components/SportCard.kt
@@ -192,7 +192,7 @@ fun SportCard(
 
 @Preview(showBackground = true)
 @Composable
-fun SportCardPreview() {
+private fun SportCardPreview() {
     Column {
         SportCard(
             teamLogo = "https://cornellbigred.com/images/logos/penn_200x200.png?width=80&height=80&mode=max", //painterResource(id = R.drawable.penn_logo),

--- a/app/src/main/java/com/cornellappdev/score/components/SportSelectorHeader.kt
+++ b/app/src/main/java/com/cornellappdev/score/components/SportSelectorHeader.kt
@@ -174,7 +174,7 @@ fun SportSelector(
 
 @Preview
 @Composable
-fun PreviewSportSelectorHeader() {
+private fun PreviewSportSelectorHeader() {
     var selectedOption by remember { mutableStateOf(GenderDivision.ALL) }
     var selectedSport: SportSelection by remember { mutableStateOf(SportSelection.All) }
 

--- a/app/src/main/java/com/cornellappdev/score/components/TimeUntilStartCard.kt
+++ b/app/src/main/java/com/cornellappdev/score/components/TimeUntilStartCard.kt
@@ -68,6 +68,6 @@ fun TimeUntilStartCard(days: Int, hours: Int) {
 
 @Preview
 @Composable
-fun TimeUntilStartCardPreview() {
+private fun TimeUntilStartCardPreview() {
     TimeUntilStartCard(2, 0)
 }

--- a/app/src/main/java/com/cornellappdev/score/components/UpcomingGameCard.kt
+++ b/app/src/main/java/com/cornellappdev/score/components/UpcomingGameCard.kt
@@ -76,7 +76,7 @@ fun UpcomingGameHeader(
 
 @Preview
 @Composable
-fun UpcomingGameHeaderPreview() {
+private fun UpcomingGameHeaderPreview() {
     UpcomingGameHeader(
         leftTeamLogo = painterResource(R.drawable.cornell_logo),
         rightTeamLogo = "https://cornellbigred.com/images/logos/YALE_LOGO_2020.png?width=80&height=80&mode=max",
@@ -96,10 +96,10 @@ fun UpcomingGameCard(
     genderIcon: Painter,
     sportIcon: Painter,
     date: String,
-    modifier: Modifier = Modifier,
-    headerModifier: Modifier,
     gradientColor1: Color,
-    gradientColor2: Color
+    gradientColor2: Color,
+    modifier: Modifier = Modifier,
+    headerModifier: Modifier = Modifier,
 ) {
     Column(
         modifier = modifier
@@ -138,7 +138,7 @@ fun UpcomingGameCard(
 
 @Preview(showBackground = true)
 @Composable
-fun GameScheduleScreen() {
+private fun GameScheduleScreen() {
     UpcomingGameCard(
         leftTeamLogo = painterResource(R.drawable.cornell_logo),
         rightTeamLogo = "https://cornellbigred.com/images/logos/penn_200x200.png?width=80&height=80&mode=max",//painterResource(R.drawable.penn_logo),

--- a/app/src/main/java/com/cornellappdev/score/screen/GameDetailsScreen.kt
+++ b/app/src/main/java/com/cornellappdev/score/screen/GameDetailsScreen.kt
@@ -94,9 +94,10 @@ fun GameDetailsScreen() {
     }
 }
 
+
 @Preview
 @Composable
-fun GameDetailsScreenPreview() {
+private fun GameDetailsScreenPreview() {
     GameDetailsScreen()
 // import androidx.compose.ui.tooling.preview.Preview
 // import androidx.compose.ui.unit.dp

--- a/app/src/main/java/com/cornellappdev/score/screen/GameScoreSummaryScreen.kt
+++ b/app/src/main/java/com/cornellappdev/score/screen/GameScoreSummaryScreen.kt
@@ -101,6 +101,6 @@ fun ScoreEventItemDetailed(event: ScoreEvent) {
 
 @Preview(showBackground = true)
 @Composable
-fun PreviewScoringDetailsScreen() {
+private fun PreviewScoringDetailsScreen() {
     GameScoreSummaryScreenDetail(scoreEvents = scoreEvents2)
 }

--- a/app/src/main/java/com/cornellappdev/score/screen/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/score/screen/HomeScreen.kt
@@ -84,10 +84,9 @@ fun HomeScreen(
     }
 }
 
-@RequiresApi(Build.VERSION_CODES.O)
 @Preview(showBackground = true)
 @Preview(showBackground = true, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
 @Composable
-fun HomeScreenPreview() {
+private fun HomeScreenPreview() {
     HomeScreen()
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
-agp = "8.6.0"
+agp = "8.8.2"
+composeLintChecks = "1.4.2"
 kotlin = "1.9.0"
 coreKtx = "1.10.1"
 junit = "4.13.2"
@@ -14,6 +15,7 @@ apollo = "4.1.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+compose-lint-checks = { module = "com.slack.lint.compose:compose-lint-checks", version.ref = "composeLintChecks" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Sep 17 00:24:01 EDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/lint.xml
+++ b/lint.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <issue id="ComposeModifierMissing" severity="informational" />
+</lint>


### PR DESCRIPTION
## Overview
We now have linting for Score! This makes our IDE smarter and highlights common code quality issues that we should avoid. Hopefully this will save us time in PR reviews. Please let me know if you get any lint errors that you think don't make sense!
## Changes Made
- Add [Compose lints](https://slackhq.github.io/compose-lints/) from Slack.
- Make all `@Preview` functions `private` to pass lint checks.
## Next steps
- Add modifiers to all public Composables to change that lint check from informational to error