### PR TITLE
Fix scrolling for home and scores screen

### DIFF
--- a/app/src/main/java/com/cornellappdev/score/components/GamesCarousel.kt
+++ b/app/src/main/java/com/cornellappdev/score/components/GamesCarousel.kt
@@ -56,12 +56,15 @@ fun DotIndicator(
 }
 
 @Composable
-fun GamesCarousel(games: List<GameCardData>, variant: GamesCarouselVariant) {
+fun GamesCarousel(
+    games: List<GameCardData>,
+    variant: GamesCarouselVariant,
+    modifier: Modifier = Modifier
+) {
     val pagerState = rememberPagerState(pageCount = { games.size })
     Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 24.dp),
+        modifier = modifier
+            .fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.Top),
     ) {
         Text(

--- a/app/src/main/java/com/cornellappdev/score/components/SportSelectorHeader.kt
+++ b/app/src/main/java/com/cornellappdev/score/components/SportSelectorHeader.kt
@@ -39,11 +39,8 @@ import com.cornellappdev.score.theme.GrayLight
 import com.cornellappdev.score.theme.GrayMedium
 import com.cornellappdev.score.theme.Style.bodyMedium
 import com.cornellappdev.score.theme.Style.bodySemibold
-import com.cornellappdev.score.theme.Style.genderFilterText
-import com.cornellappdev.score.theme.Style.genderText
 import com.cornellappdev.score.theme.Style.labelsMedium
 import com.cornellappdev.score.theme.Style.labelsNormal
-import com.cornellappdev.score.theme.Style.sportFilterText
 import com.cornellappdev.score.theme.White
 import com.cornellappdev.score.util.sportSelectionList
 
@@ -53,18 +50,17 @@ fun SportSelectorHeader(
     selectedGender: GenderDivision,
     selectedSport: SportSelection,
     onGenderSelected: (GenderDivision) -> Unit,
-    onSportSelected: (SportSelection) -> Unit
+    onSportSelected: (SportSelection) -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
-            .background(color = White)
-            .padding(start = 24.dp, bottom = 16.dp),
+            .background(color = White),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Row(
             modifier = Modifier
-                .padding(end = 24.dp)
                 .border(
                     border = BorderStroke(1.dp, GrayLight),
                     shape = RoundedCornerShape(100)

--- a/app/src/main/java/com/cornellappdev/score/screen/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/score/screen/HomeScreen.kt
@@ -1,15 +1,15 @@
 package com.cornellappdev.score.screen
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CircularProgressIndicator
@@ -22,14 +22,15 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.cornellappdev.score.components.GamesCarousel
 import com.cornellappdev.score.components.GameCard
+import com.cornellappdev.score.components.GamesCarousel
 import com.cornellappdev.score.components.SportSelectorHeader
 import com.cornellappdev.score.model.ApiResponse
 import com.cornellappdev.score.model.GamesCarouselVariant
 import com.cornellappdev.score.model.GenderDivision
 import com.cornellappdev.score.model.SportSelection
 import com.cornellappdev.score.theme.Style.title
+import com.cornellappdev.score.theme.White
 import com.cornellappdev.score.util.gameList
 import com.cornellappdev.score.util.sportSelectionList
 import com.cornellappdev.score.viewmodel.HomeUiState
@@ -45,7 +46,6 @@ fun HomeScreen(
     Column(
         verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.Top),
         modifier = Modifier
-            .statusBarsPadding()
             .background(Color.White)
     ) {
         when (uiState.loadedState) {
@@ -83,6 +83,7 @@ fun HomeScreen(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun HomeContent(
     uiState: HomeUiState,
@@ -90,39 +91,46 @@ private fun HomeContent(
     onSportSelected: (SportSelection) -> Unit,
     navigateToGameDetails: (Boolean) -> Unit = {}
 ) {
-    GamesCarousel(uiState.upcomingGames, GamesCarouselVariant.UPCOMING)
-    Column {
-        Text(
-            text = "Game Schedule",
-            style = title,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 24.dp, vertical = 8.dp)
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        SportSelectorHeader(
-            sports = uiState.selectionList,
-            selectedGender = uiState.selectedGender,
-            selectedSport = uiState.sportSelect,
-            onGenderSelected = onGenderSelected,
-            onSportSelected = onSportSelected
-        )
-        LazyColumn(modifier = Modifier.padding(horizontal = 24.dp)) {
-            items(uiState.filteredGames) {
-                val game = it
-                GameCard(
-                    teamLogo = game.teamLogo,
-                    team = game.team,
-                    date = game.dateString,
-                    isLive = game.isLive,
-                    genderIcon = painterResource(game.genderIcon),
-                    sportIcon = painterResource(game.sportIcon),
-                    location = game.location,
-                    topCornerRound = true,
-                    onClick = navigateToGameDetails
+    LazyColumn(contentPadding = PaddingValues(top = 24.dp, start = 24.dp, end = 24.dp)) {
+        item {
+            GamesCarousel(uiState.upcomingGames, GamesCarouselVariant.UPCOMING)
+        }
+        stickyHeader {
+            Column(modifier = Modifier.background(White)) {
+                Spacer(Modifier.height(24.dp))
+                Text(
+                    text = "Game Schedule",
+                    style = title,
+                    modifier = Modifier
+                        .fillMaxWidth()
                 )
-                Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(8.dp))
+                SportSelectorHeader(
+                    sports = uiState.selectionList,
+                    selectedGender = uiState.selectedGender,
+                    selectedSport = uiState.sportSelect,
+                    onGenderSelected = onGenderSelected,
+                    onSportSelected = onSportSelected,
+                )
             }
+        }
+        item {
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+        items(uiState.filteredGames) {
+            val game = it
+            GameCard(
+                teamLogo = game.teamLogo,
+                team = game.team,
+                date = game.dateString,
+                isLive = game.isLive,
+                genderIcon = painterResource(game.genderIcon),
+                sportIcon = painterResource(game.sportIcon),
+                location = game.location,
+                topCornerRound = true,
+                onClick = navigateToGameDetails
+            )
+            Spacer(modifier = Modifier.height(16.dp))
         }
     }
 }

--- a/app/src/main/java/com/cornellappdev/score/screen/PastGamesScreen.kt
+++ b/app/src/main/java/com/cornellappdev/score/screen/PastGamesScreen.kt
@@ -1,45 +1,37 @@
 package com.cornellappdev.score.screen
 
-import android.os.Build
-import androidx.annotation.RequiresApi
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
-import android.util.Log
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import com.cornellappdev.score.components.GameCard
-import com.cornellappdev.score.components.SportSelectorHeader
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.cornellappdev.score.components.GamesCarousel
 import com.cornellappdev.score.components.PastGameCard
+import com.cornellappdev.score.components.SportSelectorHeader
 import com.cornellappdev.score.model.ApiResponse
-import com.cornellappdev.score.model.GameCardData
 import com.cornellappdev.score.model.GamesCarouselVariant
 import com.cornellappdev.score.model.GenderDivision
 import com.cornellappdev.score.model.SportSelection
-import com.cornellappdev.score.theme.Style.heading1
 import com.cornellappdev.score.theme.Style.title
 import com.cornellappdev.score.theme.White
-import com.cornellappdev.score.viewmodel.HomeUiState
-import com.cornellappdev.score.viewmodel.HomeViewModel
+import com.cornellappdev.score.util.gameList
+import com.cornellappdev.score.util.sportSelectionList
 import com.cornellappdev.score.viewmodel.PastGamesUiState
 import com.cornellappdev.score.viewmodel.PastGamesViewModel
 
@@ -53,7 +45,6 @@ fun PastGamesScreen(
     Column(
         verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.Top),
         modifier = Modifier
-            .statusBarsPadding()
             .background(Color.White)
     ) {
         when (uiState.loadedState) {
@@ -91,6 +82,7 @@ fun PastGamesScreen(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun PastGamesContent(
     uiState: PastGamesUiState,
@@ -98,32 +90,54 @@ private fun PastGamesContent(
     onSportSelected: (SportSelection) -> Unit,
     navigateToGameDetails: (Boolean) -> Unit = {}
 ) {
-    GamesCarousel(uiState.pastGames, GamesCarouselVariant.PAST)
-    Column {
-        Text(
-            text = "All Scores",
-            style = title,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 24.dp, vertical = 8.dp)
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        SportSelectorHeader(
-            sports = uiState.selectionList,
-            selectedGender = uiState.selectedGender,
-            selectedSport = uiState.sportSelect,
-            onGenderSelected = onGenderSelected,
-            onSportSelected = onSportSelected
-        )
-        LazyColumn(modifier = Modifier.padding(horizontal = 24.dp)) {
-            items(uiState.filteredGames) {
-                val game = it
-                PastGameCard(
-                    data = game,
-                    onClick = navigateToGameDetails
+    LazyColumn(contentPadding = PaddingValues(top = 24.dp, start = 24.dp, end = 24.dp)) {
+        item {
+            GamesCarousel(uiState.pastGames, GamesCarouselVariant.PAST)
+        }
+        stickyHeader {
+            Column(modifier = Modifier.background(White)) {
+                Spacer(Modifier.height(24.dp))
+                Text(
+                    text = "All Scores",
+                    style = title,
+                    modifier = Modifier
+                        .fillMaxWidth()
                 )
-                Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(8.dp))
+                SportSelectorHeader(
+                    sports = uiState.selectionList,
+                    selectedGender = uiState.selectedGender,
+                    selectedSport = uiState.sportSelect,
+                    onGenderSelected = onGenderSelected,
+                    onSportSelected = onSportSelected
+                )
             }
         }
+        item {
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+        items(uiState.filteredGames) {
+            val game = it
+            PastGameCard(
+                data = game,
+                onClick = navigateToGameDetails
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+        }
     }
+}
+
+@Composable
+@Preview
+private fun PastGamesPreview() {
+    PastGamesContent(
+        uiState = PastGamesUiState(
+            selectedGender = GenderDivision.ALL,
+            sportSelect = SportSelection.All,
+            selectionList = sportSelectionList,
+            loadedState = ApiResponse.Success(gameList)
+        ),
+        onGenderSelected = {},
+        onSportSelected = {},
+    )
 }

--- a/app/src/main/java/com/cornellappdev/score/util/TestingConstants.kt
+++ b/app/src/main/java/com/cornellappdev/score/util/TestingConstants.kt
@@ -40,7 +40,16 @@ val PRINCETON_GAME = GameCardData(
     sport = "Swim Dive",
     sportIcon = R.drawable.ic_swim_dive,
 )
-val gameList = listOf(PENN_GAME, PRINCETON_GAME)
+val gameList = listOf(
+    PENN_GAME,
+    PRINCETON_GAME,
+    PENN_GAME,
+    PRINCETON_GAME,
+    PENN_GAME,
+    PRINCETON_GAME,
+    PENN_GAME,
+    PRINCETON_GAME
+)
 
 val team1 = Team(name = "Cornell", R.drawable.cornell_logo)
 val team2 = Team(name = "Yale", R.drawable.yale_logo)


### PR DESCRIPTION

## Overview
- Refactor home screen to use `LazyColumn` and `stickyHeader` for full screen scrolling.
- Refactor scores screen to use `LazyColumn` and `stickyHeader` for full screen scrolling.


## Test Coverage

### Home screen scrolling
https://github.com/user-attachments/assets/5e875df1-2257-4890-940a-4d3e5c85fd15

### Past game screen scrolling
https://github.com/user-attachments/assets/9a015983-acf4-4315-a844-a95d3c5b333f


