### PR TITLE
ScoreBox fix (+ lacrosse icon mini fix)

### DIFF
--- a/app/src/main/java/com/cornellappdev/score/components/ScoreBox.kt
+++ b/app/src/main/java/com/cornellappdev/score/components/ScoreBox.kt
@@ -110,8 +110,7 @@ private fun TeamNameColumn(
             //set to approximation of minimum width for "Cornell"
             modifier.widthIn(max = 70.dp)
         } else {
-            //can take up as much space as is available
-            modifier.width(IntrinsicSize.Max)
+            modifier.widthIn(max = 100.dp)
         }
     ) {
         Row(
@@ -294,7 +293,7 @@ private fun CompleteTableData(
             teamTwoScores = gameData.teamScores.second,
             //if maxPeriods > 8, "Totals" header will wrap to two lines. In this case, don't weight so that space is allocated to TotalsColumn first
             //otherwise, TotalsColumn will fit without wrapping and can be allocated equal width as the data columns
-            modifier = if (maxPeriods < 8) {
+            modifier = if (maxPeriods < 4) {
                 Modifier.weight(1f, fill = true)
             } else {
                 Modifier
@@ -386,38 +385,39 @@ private fun TotalsColumn(
 }
 
 
+//Padding added to previews to simulate the padding around the ScoreBox when it's displayed on the screen
 @Preview
 @Composable
 private fun PreviewBoxScore() = ScorePreview {
-    BoxScore(gameData = gameData)
+    BoxScore(gameData = gameData, Modifier.padding(start = 20.dp, end = 20.dp))
 }
 
 @Preview
 @Composable
 private fun PreviewBoxScoreForLongGame() = ScorePreview {
-    BoxScore(longGameData)
+    BoxScore(longGameData, Modifier.padding(start = 20.dp, end = 20.dp))
 }
 
 @Preview
 @Composable
 private fun PreviewBoxScoreForMedGame() = ScorePreview {
-    BoxScore(mediumGameData)
+    BoxScore(mediumGameData, Modifier.padding(start = 20.dp, end = 20.dp))
 }
 
 @Preview
 @Composable
 private fun PreviewBoxScoreForShortGame() = ScorePreview {
-    BoxScore(shortGameData)
+    BoxScore(shortGameData, Modifier.padding(start = 20.dp, end = 20.dp))
 }
 
 @Preview
 @Composable
 private fun PreviewBoxScoreExtraLongGame() = ScorePreview {
-    BoxScore(gameData = extraLongGameData)
+    BoxScore(gameData = extraLongGameData, Modifier.padding(start = 20.dp, end = 20.dp))
 }
 
 @Preview
 @Composable
 private fun PreviewBoxScoreEmpty() = ScorePreview {
-    BoxScore(gameData = emptyGameData())
+    BoxScore(gameData = emptyGameData(), Modifier.padding(start = 20.dp, end = 20.dp))
 }

--- a/app/src/main/java/com/cornellappdev/score/components/ScoreBox.kt
+++ b/app/src/main/java/com/cornellappdev/score/components/ScoreBox.kt
@@ -47,8 +47,8 @@ import com.cornellappdev.score.util.mediumGameData
 import com.cornellappdev.score.util.shortGameData
 
 private val HEADER_HEIGHT = 35.dp
-private val SMALL_BOX_SIZE = 4
-private val LARGE_BOX_SIZE = 10
+private const val SMALL_BOX_SIZE = 4
+private const val LARGE_BOX_SIZE = 10
 
 @Composable
 fun BoxScore(

--- a/app/src/main/java/com/cornellappdev/score/components/ScoreBox.kt
+++ b/app/src/main/java/com/cornellappdev/score/components/ScoreBox.kt
@@ -2,19 +2,23 @@ package com.cornellappdev.score.components
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -24,132 +28,280 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.cornellappdev.score.model.GameData
 import com.cornellappdev.score.model.TeamScore
+import com.cornellappdev.score.model.mapToPeriodScores
 import com.cornellappdev.score.theme.CrimsonPrimary
 import com.cornellappdev.score.theme.GrayMedium
 import com.cornellappdev.score.theme.GrayPrimary
-import com.cornellappdev.score.theme.Style.bodyNormal
-import com.cornellappdev.score.theme.Style.labelsNormal
+import com.cornellappdev.score.theme.Style.metricNormal
+import com.cornellappdev.score.theme.Style.metricSmallNormal
 import com.cornellappdev.score.theme.saturatedGreen
 import com.cornellappdev.score.util.emptyGameData
 import com.cornellappdev.score.util.gameData
 import com.cornellappdev.score.util.longGameData
 import com.cornellappdev.score.util.mediumGameData
+import com.cornellappdev.score.util.shortGameData
 
 @Composable
-fun BoxScore(gameData: GameData) {
+fun BoxScore(
+    gameData: GameData,
+    modifier: Modifier = Modifier
+) {
     val maxPeriods = maxOf(
         gameData.teamScores.first.scoresByPeriod.size,
         gameData.teamScores.second.scoresByPeriod.size
     )
-    val rowTextStyle = if (maxPeriods > 4) labelsNormal else bodyNormal
+    val rowTextStyle = if (maxPeriods > 4) metricSmallNormal else metricNormal
+
+    Surface(
+        modifier = modifier
+            .fillMaxWidth(),
+        shape = RoundedCornerShape(8.dp),
+        border = (BorderStroke(width = 1.dp, color = CrimsonPrimary)),
+        shadowElevation = 8.dp,
+        color = Color.White
+    ) {
+        Row(
+            modifier = Modifier
+                .height(IntrinsicSize.Max)
+                .fillMaxWidth()
+        ) {
+            TeamNameColumn(
+                gameData.teamScores.first.team.name,
+                gameData.teamScores.second.team.name,
+                rowTextStyle
+            )
+            CompleteTableData(
+                gameData = gameData,
+                rowTextStyle = rowTextStyle
+            )
+        }
+    }
+}
+
+@Composable
+private fun TeamNameColumn(
+    teamOneName: String,
+    teamTwoName: String,
+    rowTextStyle: TextStyle,
+    modifier: Modifier = Modifier
+) {
     Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(shape = RoundedCornerShape(8.dp))
-            .background(color = Color.White, shape = RoundedCornerShape(8.dp))
-            .border(BorderStroke(width = 1.dp, color = CrimsonPrimary))
+        modifier = modifier.width(60.dp)
+        //.width(IntrinsicSize.Max)
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .background(color = CrimsonPrimary)
-                .padding(top = 6.dp, bottom = 4.dp, end = 8.dp),
-            verticalAlignment = Alignment.CenterVertically
+                .weight(1F)
+                .padding(top = 6.dp, bottom = 4.dp)
+        ) {}
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1F)
+                .padding(top = 8.dp, bottom = 8.dp)
         ) {
             Text(
-                text = "",
-                modifier = Modifier.weight(1f),
-                color = Color.White,
-                textAlign = TextAlign.Center
-            )
-            repeat(maxPeriods) { period ->
-                Text(
-                    text = "${period + 1}",
-                    modifier = Modifier.weight(1f),
-                    color = Color.White,
-                    style = rowTextStyle,
-                    textAlign = TextAlign.Center
-                )
-            }
-            Text(
-                text = "Total",
-                modifier = Modifier.weight(1f),
+                text = teamOneName,
                 style = rowTextStyle,
-                color = Color.White,
-                textAlign = TextAlign.Center
+                color = GrayPrimary,
+                modifier = Modifier
+                    .weight(1f, fill = true)
+                    .padding(10.dp),
+                textAlign = TextAlign.Left,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
             )
         }
-        TeamScoreRow(
-            teamScore = gameData.teamScores.first,
-            totalTextColor = saturatedGreen,
-            maxPeriods,
-            rowTextStyle
-        )
         HorizontalDivider(thickness = 1.dp, color = CrimsonPrimary)
-
-        TeamScoreRow(
-            teamScore = gameData.teamScores.second,
-            totalTextColor = GrayMedium,
-            maxPeriods,
-            rowTextStyle
-        )
-
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+                .padding(top = 8.dp, bottom = 8.dp)
+        ) {
+            Text(
+                text = teamTwoName,
+                style = rowTextStyle,
+                color = GrayPrimary,
+                modifier = Modifier
+                    .weight(1f, fill = true)
+                    .padding(10.dp),
+                textAlign = TextAlign.Left,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
     }
 }
 
 @Composable
-fun TeamScoreRow(
+private fun TableDataColumn(
+    header: Int,
+    team1Score: String,
+    team2Score: String,
+    rowTextStyle: TextStyle,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxHeight()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(color = CrimsonPrimary)
+                .weight(1f),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = header.toString(),
+                color = Color.White,
+                style = rowTextStyle,
+                textAlign = TextAlign.Center
+            )
+        }
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = team1Score,
+                style = rowTextStyle,
+                textAlign = TextAlign.Center
+            )
+        }
+        HorizontalDivider(thickness = 1.dp, color = CrimsonPrimary)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = team2Score,
+                style = rowTextStyle,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+@Composable
+private fun CompleteTableData(
+    gameData: GameData,
+    rowTextStyle: TextStyle,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        val periodScores = mapToPeriodScores(gameData)
+
+        if (periodScores.isNotEmpty()) {
+            mapToPeriodScores(gameData).map { periodScore ->
+                TableDataColumn(
+                    header = periodScore.header,
+                    team1Score = periodScore.teamOneScore,
+                    team2Score = periodScore.teamTwoScore,
+                    rowTextStyle = rowTextStyle,
+                    modifier = Modifier.weight(1f)
+                )
+            }
+        } else {
+            for (i in 1..4) {
+                TableDataColumn(
+                    header = i,
+                    team1Score = "-",
+                    team2Score = "-",
+                    rowTextStyle = rowTextStyle,
+                    modifier = Modifier.weight(1f)
+                )
+            }
+        }
+
+        TotalsColumn(
+            teamOneScores = gameData.teamScores.first,
+            teamTwoScores = gameData.teamScores.second,
+            modifier = Modifier.width(IntrinsicSize.Min),
+            //.weight(1f),
+            rowTextStyle = rowTextStyle
+        )
+    }
+}
+
+@Composable
+private fun TotalScoreCell(
     teamScore: TeamScore,
     totalTextColor: Color,
-    maxPeriods: Int,
-    rowTextStyle: TextStyle
+    rowTextStyle: TextStyle,
+    modifier: Modifier = Modifier
 ) {
     val showEmpty = teamScore.scoresByPeriod.isEmpty()
-
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 8.dp, horizontal = 10.dp),
-        horizontalArrangement = Arrangement.SpaceBetween,
+        modifier = modifier
+            .fillMaxSize()
+            .padding(top = 8.dp, bottom = 8.dp, end = 8.dp),
+        horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(
-            text = teamScore.team.name,
-            style = rowTextStyle,
-            color = GrayPrimary,
-            modifier = Modifier.weight(1f),
-            textAlign = TextAlign.Center,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis
-        )
-
-        teamScore.scoresByPeriod.forEach { score ->
-            Text(
-                text = if (showEmpty) "-" else score.toString(),
-                modifier = Modifier.weight(1f),
-                style = rowTextStyle,
-                color = GrayPrimary,
-                textAlign = TextAlign.Center
-            )
-        }
-
-        repeat(maxPeriods - teamScore.scoresByPeriod.size) {
-            Text(
-                text = "-",
-                modifier = Modifier.weight(1f),
-                style = rowTextStyle,
-                color = GrayPrimary,
-                textAlign = TextAlign.Center
-            )
-        }
-
-        Text(
             text = if (showEmpty) "-" else teamScore.totalScore.toString(),
-            modifier = Modifier.weight(1f),
             style = rowTextStyle,
             color = if (showEmpty) Color.Gray else totalTextColor,
             fontWeight = if (showEmpty) FontWeight.Normal else FontWeight.Bold,
             textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Composable
+private fun TotalsColumn(
+    teamOneScores: TeamScore,
+    teamTwoScores: TeamScore,
+    rowTextStyle: TextStyle,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(color = CrimsonPrimary)
+                .padding(end = 8.dp)
+                .weight(1f),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "Total",
+                color = Color.White,
+                style = rowTextStyle,
+                textAlign = TextAlign.Center
+            )
+        }
+
+        TotalScoreCell(
+            teamScore = teamOneScores,
+            totalTextColor = saturatedGreen,
+            rowTextStyle = rowTextStyle,
+            modifier = Modifier.weight(1f)
+        )
+        HorizontalDivider(thickness = 1.dp, color = CrimsonPrimary)
+        TotalScoreCell(
+            teamScore = teamTwoScores,
+            totalTextColor = GrayMedium,
+            rowTextStyle = rowTextStyle,
+            modifier = Modifier.weight(1f)
         )
     }
 }
@@ -175,13 +327,12 @@ private fun PreviewBoxScoreForMedGame() = ScorePreview {
 
 @Preview
 @Composable
-private fun PreviewBoxScoreEmpty() = ScorePreview {
-    BoxScore(gameData = emptyGameData())
+private fun PreviewBoxScoreForShortGame() = ScorePreview {
+    BoxScore(shortGameData)
 }
-
 
 @Preview
 @Composable
-private fun PreviewTeamScoreRow() = ScorePreview {
-    TeamScoreRow(gameData.teamScores.first, GrayMedium, 4, bodyNormal)
+private fun PreviewBoxScoreEmpty() = ScorePreview {
+    BoxScore(gameData = emptyGameData())
 }

--- a/app/src/main/java/com/cornellappdev/score/components/ScoreBox.kt
+++ b/app/src/main/java/com/cornellappdev/score/components/ScoreBox.kt
@@ -363,14 +363,22 @@ private fun TotalsColumn(
 
         TotalScoreCell(
             teamScore = teamOneScores,
-            totalTextColor = if (totalOne > totalTwo){saturatedGreen}else{GrayMedium},
+            totalTextColor = if (totalOne > totalTwo) {
+                saturatedGreen
+            } else {
+                GrayMedium
+            },
             rowTextStyle = rowTextStyle,
             modifier = Modifier.weight(1f)
         )
         HorizontalDivider(thickness = 1.dp, color = CrimsonPrimary)
         TotalScoreCell(
             teamScore = teamTwoScores,
-            totalTextColor = if (totalTwo > totalOne){saturatedGreen}else{GrayMedium},
+            totalTextColor = if (totalTwo > totalOne) {
+                saturatedGreen
+            } else {
+                GrayMedium
+            },
             rowTextStyle = rowTextStyle,
             modifier = Modifier.weight(1f)
         )

--- a/app/src/main/java/com/cornellappdev/score/components/ScoreBox.kt
+++ b/app/src/main/java/com/cornellappdev/score/components/ScoreBox.kt
@@ -107,8 +107,10 @@ private fun TeamNameColumn(
 ) {
     Column(
         modifier = if (maxPeriods > 4) {
+            //set to approximation of minimum width for "Cornell"
             modifier.widthIn(max = 70.dp)
         } else {
+            //can take up as much space as is available
             modifier.width(IntrinsicSize.Max)
         }
     ) {
@@ -356,16 +358,19 @@ private fun TotalsColumn(
             )
         }
 
+        val totalOne = teamOneScores.totalScore
+        val totalTwo = teamTwoScores.totalScore
+
         TotalScoreCell(
             teamScore = teamOneScores,
-            totalTextColor = saturatedGreen,
+            totalTextColor = if (totalOne > totalTwo){saturatedGreen}else{GrayMedium},
             rowTextStyle = rowTextStyle,
             modifier = Modifier.weight(1f)
         )
         HorizontalDivider(thickness = 1.dp, color = CrimsonPrimary)
         TotalScoreCell(
             teamScore = teamTwoScores,
-            totalTextColor = GrayMedium,
+            totalTextColor = if (totalTwo > totalOne){saturatedGreen}else{GrayMedium},
             rowTextStyle = rowTextStyle,
             modifier = Modifier.weight(1f)
         )

--- a/app/src/main/java/com/cornellappdev/score/components/ScoreBox.kt
+++ b/app/src/main/java/com/cornellappdev/score/components/ScoreBox.kt
@@ -3,21 +3,17 @@ package com.cornellappdev.score.components
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.ButtonGroupDefaults.HorizontalArrangement
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -58,11 +54,16 @@ fun BoxScore(
         gameData.teamScores.first.scoresByPeriod.size,
         gameData.teamScores.second.scoresByPeriod.size
     )
-    val rowTextStyle = if (maxPeriods > 4) metricSmallNormal else metricNormal
+
+    val rowTextStyle = if (maxPeriods > 4) {
+        metricSmallNormal
+    } else {
+        metricNormal
+    }
 
     Surface(
         modifier = modifier
-            //.height(IntrinsicSize.Min)
+            //set height required for CompleteLazyTableData case
             .height(160.dp)
             .fillMaxWidth(),
         shape = RoundedCornerShape(8.dp),
@@ -80,12 +81,12 @@ fun BoxScore(
                 rowTextStyle,
                 maxPeriods
             )
-            if (maxPeriods > 10){
+            if (maxPeriods > 10) {
                 CompleteLazyTableData(
                     gameData = gameData,
                     rowTextStyle = rowTextStyle
                 )
-            }else{
+            } else {
                 CompleteTableData(
                     gameData = gameData,
                     rowTextStyle = rowTextStyle,
@@ -224,41 +225,32 @@ private fun CompleteLazyTableData(
     rowTextStyle: TextStyle,
     modifier: Modifier = Modifier
 ) {
-    //todo: lazy row for maxPeriods > 10
     val periodScores = mapToPeriodScores(gameData)
 
     if (periodScores.isNotEmpty()) {
-        Row{
-//            Box(
-//                modifier = Modifier//.weight(1f)
-//                    .fillMaxWidth()
-//            ){
-                LazyRow(
-                    modifier = Modifier.weight(1f),
-                    //horizontalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    items(periodScores) { periodScore ->
-                        TableDataColumn(
-                            header = periodScore.header,
-                            teamOneScore = periodScore.teamOneScore,
-                            teamTwoScore = periodScore.teamTwoScore,
-                            rowTextStyle = rowTextStyle,
-                            modifier = Modifier.width(35.dp)
-                        )
-                    }
+        Row(
+            modifier = modifier
+        ) {
+            LazyRow(
+                modifier = Modifier.weight(1f)
+            ) {
+                items(periodScores) { periodScore ->
+                    TableDataColumn(
+                        header = periodScore.header,
+                        teamOneScore = periodScore.teamOneScore,
+                        teamTwoScore = periodScore.teamTwoScore,
+                        rowTextStyle = rowTextStyle,
+                        modifier = Modifier.width(35.dp)
+                    )
                 }
-            //}
+            }
             TotalsColumn(
                 teamOneScores = gameData.teamScores.first,
                 teamTwoScores = gameData.teamScores.second,
-//                modifier = Modifier
-//                    .width(IntrinsicSize.Max),
-                //.weight(1f),
                 rowTextStyle = rowTextStyle
             )
         }
     }
-
 }
 
 @Composable
@@ -271,8 +263,9 @@ private fun CompleteTableData(
     val periodScores = mapToPeriodScores(gameData)
 
     Row(
+        modifier = modifier,
         horizontalArrangement = Arrangement.SpaceEvenly
-    ){
+    ) {
         if (periodScores.isNotEmpty()) {
             mapToPeriodScores(gameData).map { periodScore ->
                 TableDataColumn(
@@ -295,13 +288,17 @@ private fun CompleteTableData(
             }
         }
         TotalsColumn(
-                teamOneScores = gameData.teamScores.first,
-                teamTwoScores = gameData.teamScores.second,
-                modifier = Modifier
-                    //.width(IntrinsicSize.Min)
-                    .weight(1f, fill = true),
-                rowTextStyle = rowTextStyle
-            )
+            teamOneScores = gameData.teamScores.first,
+            teamTwoScores = gameData.teamScores.second,
+            //if maxPeriods > 8, "Totals" header will wrap to two lines. In this case, don't weight so that space is allocated to TotalsColumn first
+            //otherwise, TotalsColumn will fit without wrapping and can be allocated equal width as the data columns
+            modifier = if (maxPeriods < 8) {
+                Modifier.weight(1f, fill = true)
+            } else {
+                Modifier
+            },
+            rowTextStyle = rowTextStyle
+        )
     }
 
 }
@@ -340,9 +337,7 @@ private fun TotalsColumn(
 ) {
     Column(
         modifier = modifier
-            //.wrapContentHeight()
             .width(IntrinsicSize.Min)
-            //.widthIn(min = 50.dp)
     ) {
         Row(
             modifier = Modifier

--- a/app/src/main/java/com/cornellappdev/score/model/Game.kt
+++ b/app/src/main/java/com/cornellappdev/score/model/Game.kt
@@ -1,5 +1,6 @@
 package com.cornellappdev.score.model
 
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import com.cornellappdev.score.R
 import com.cornellappdev.score.util.convertScores
@@ -130,6 +131,12 @@ data class DetailsCardData(
 )
 
 // Scoring information for a specific team, used in the box score
+data class ScoresByPeriod(
+    val header: Int,
+    val teamOneScore: String,
+    val teamTwoScore: String
+)
+
 data class TeamScore(
     val team: TeamBoxScore,
     val scoresByPeriod: List<Int>,
@@ -290,5 +297,22 @@ fun List<GameDetailsBoxScore>.toScoreEvents(teamLogo: String): List<ScoreEvent> 
             score = "$corScore - $oppScore",
             description = boxScore.description
         )
+    }
+}
+
+fun mapToPeriodScores(gameData: GameData): List<ScoresByPeriod>{
+    val teamOneScores = gameData.teamScores.first.scoresByPeriod
+    val teamTwoScores = gameData.teamScores.second.scoresByPeriod
+
+    val maxPeriods = maxOf(teamOneScores.size, teamTwoScores.size)
+
+    return (0 until maxPeriods).map { i ->
+        ScoresByPeriod(
+            header = i + 1,
+            teamOneScore = teamOneScores.getOrNull(i)?.toString() ?: "-",
+            teamTwoScore = teamTwoScores.getOrNull(i)?.toString() ?: "-"
+
+        )
+
     }
 }

--- a/app/src/main/java/com/cornellappdev/score/model/Game.kt
+++ b/app/src/main/java/com/cornellappdev/score/model/Game.kt
@@ -146,7 +146,31 @@ data class TeamScore(
 // Aggregated game data showing scores for both teams
 data class GameData(
     val teamScores: Pair<TeamScore, TeamScore>
-)
+){
+    val maxPeriods: Int
+        get() =
+            maxOf(
+                teamScores.first.scoresByPeriod.size,
+                teamScores.second.scoresByPeriod.size
+            )
+
+    fun mapToPeriodScores(): List<ScoresByPeriod> {
+        val teamOneScores = this.teamScores.first.scoresByPeriod
+        val teamTwoScores = this.teamScores.second.scoresByPeriod
+
+        val maxPeriods = maxOf(teamOneScores.size, teamTwoScores.size)
+
+        return (0 until maxPeriods).map { i ->
+            ScoresByPeriod(
+                header = i + 1,
+                teamOneScore = teamOneScores.getOrNull(i)?.toString() ?: "-",
+                teamTwoScore = teamTwoScores.getOrNull(i)?.toString() ?: "-"
+
+            )
+
+        }
+    }
+}
 
 /**
  * Represents a scoring event in a game.
@@ -297,22 +321,5 @@ fun List<GameDetailsBoxScore>.toScoreEvents(teamLogo: String): List<ScoreEvent> 
             score = "$corScore - $oppScore",
             description = boxScore.description
         )
-    }
-}
-
-fun mapToPeriodScores(gameData: GameData): List<ScoresByPeriod> {
-    val teamOneScores = gameData.teamScores.first.scoresByPeriod
-    val teamTwoScores = gameData.teamScores.second.scoresByPeriod
-
-    val maxPeriods = maxOf(teamOneScores.size, teamTwoScores.size)
-
-    return (0 until maxPeriods).map { i ->
-        ScoresByPeriod(
-            header = i + 1,
-            teamOneScore = teamOneScores.getOrNull(i)?.toString() ?: "-",
-            teamTwoScore = teamTwoScores.getOrNull(i)?.toString() ?: "-"
-
-        )
-
     }
 }

--- a/app/src/main/java/com/cornellappdev/score/model/Game.kt
+++ b/app/src/main/java/com/cornellappdev/score/model/Game.kt
@@ -130,13 +130,14 @@ data class DetailsCardData(
     val oppScore: Int
 )
 
-// Scoring information for a specific team, used in the box score
+// Scoring information by round of a game, used in the box score
 data class ScoresByPeriod(
     val header: Int,
     val teamOneScore: String,
     val teamTwoScore: String
 )
 
+// Scoring information for a specific team, used in the box score
 data class TeamScore(
     val team: TeamBoxScore,
     val scoresByPeriod: List<Int>,

--- a/app/src/main/java/com/cornellappdev/score/model/Game.kt
+++ b/app/src/main/java/com/cornellappdev/score/model/Game.kt
@@ -1,6 +1,5 @@
 package com.cornellappdev.score.model
 
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import com.cornellappdev.score.R
 import com.cornellappdev.score.util.convertScores
@@ -301,7 +300,7 @@ fun List<GameDetailsBoxScore>.toScoreEvents(teamLogo: String): List<ScoreEvent> 
     }
 }
 
-fun mapToPeriodScores(gameData: GameData): List<ScoresByPeriod>{
+fun mapToPeriodScores(gameData: GameData): List<ScoresByPeriod> {
     val teamOneScores = gameData.teamScores.first.scoresByPeriod
     val teamTwoScores = gameData.teamScores.second.scoresByPeriod
 

--- a/app/src/main/java/com/cornellappdev/score/model/Sport.kt
+++ b/app/src/main/java/com/cornellappdev/score/model/Sport.kt
@@ -87,8 +87,8 @@ enum class Sport(
     LACROSSE(
         displayName = "Lacrosse",
         gender = GenderDivision.ALL,
-        emptyIcon = R.drawable.ic_squash,
-        filledIcon = R.drawable.ic_squash_filled
+        emptyIcon = R.drawable.ic_lacrosse,
+        filledIcon = R.drawable.ic_lacrosse_filled
     ),
     ROWING_HEAVYWEIGHT(
         displayName = "Heavyweight Rowing",

--- a/app/src/main/java/com/cornellappdev/score/theme/TextStyle.kt
+++ b/app/src/main/java/com/cornellappdev/score/theme/TextStyle.kt
@@ -196,6 +196,12 @@ object Style {
         fontWeight = FontWeight(500)
     )
 
+    val metricSmallNormal = TextStyle(
+        fontSize = 14.sp,
+        fontFamily = poppinsFamily,
+        fontWeight = FontWeight(400)
+    )
+
     val metricNormal = TextStyle(
         fontSize = 18.sp,
         fontFamily = poppinsFamily,

--- a/app/src/main/java/com/cornellappdev/score/util/TestingConstants.kt
+++ b/app/src/main/java/com/cornellappdev/score/util/TestingConstants.kt
@@ -100,7 +100,18 @@ val longGameTeamScore2 = TeamScore(
     team = team1,
     scoresByPeriod = listOf(7, 7, 9, 0, 7, 7, 9, 0, 7, 2),
     totalScore = 47
+
+val extraLongGameTeamScore1 = TeamScore(
+    team = team1,
+    scoresByPeriod = listOf(13, 14, 6, 14, 13, 2, 4, 6, 2, 2, 3, 4),
+    totalScore = 54
 )
+val extraLongGameTeamScore2 = TeamScore(
+    team = team1,
+    scoresByPeriod = listOf(7, 7, 9, 0, 7, 7, 9, 0, 7, 2, 1, 1),
+    totalScore = 49
+)
+
 val gameData = GameData(teamScores = Pair(teamScore1, teamScore2))
 
 val shortGameData = GameData(teamScores = shortGameTeamScore1 to shortGameTeamScore2)
@@ -108,6 +119,8 @@ val shortGameData = GameData(teamScores = shortGameTeamScore1 to shortGameTeamSc
 val mediumGameData = GameData(teamScores = mediumGameTeamScore1 to mediumGameTeamScore2)
 
 val longGameData = GameData(teamScores = longGameTeamScore1 to longGameTeamScore2)
+
+val extraLongGameData = GameData(teamScores = extraLongGameTeamScore1 to extraLongGameTeamScore2)
 
 val team3 = TeamGameSummary(
     name = "Cornell",

--- a/app/src/main/java/com/cornellappdev/score/util/TestingConstants.kt
+++ b/app/src/main/java/com/cornellappdev/score/util/TestingConstants.kt
@@ -55,7 +55,7 @@ val gameList = listOf(
 )
 
 val team1 = TeamBoxScore(name = "Cornell")
-val team2 = TeamBoxScore(name = "Yale")
+val team2 = TeamBoxScore(name = "Yale University")
 
 val teamScore1 = TeamScore(
     team = team1,
@@ -129,7 +129,7 @@ val team3 = TeamGameSummary(
     "https://cornellbigred.com/images/logos/penn_200x200.png?width=80&height=80&mode=max"
 )
 val team4 = TeamGameSummary(
-    name = "Yale",
+    name = "Yale University",
     "https://cornellbigred.com/images/logos/penn_200x200.png?width=80&height=80&mode=max"
 )
 val scoreEvents1 = listOf(

--- a/app/src/main/java/com/cornellappdev/score/util/TestingConstants.kt
+++ b/app/src/main/java/com/cornellappdev/score/util/TestingConstants.kt
@@ -82,13 +82,13 @@ val shortGameTeamScore2 = TeamScore(
 
 val mediumGameTeamScore1 = TeamScore(
     team = team1,
-    scoresByPeriod = listOf(13, 14, 6, 14, 13, 2),
-    totalScore = 62
-)
-val mediumGameTeamScore2 = TeamScore(
-    team = team1,
     scoresByPeriod = listOf(7, 7, 9, 0, 7, 7),
     totalScore = 37
+)
+val mediumGameTeamScore2 = TeamScore(
+    team = team2,
+    scoresByPeriod = listOf(13, 14, 6, 14, 13, 2),
+    totalScore = 62
 )
 
 val longGameTeamScore1 = TeamScore(

--- a/app/src/main/java/com/cornellappdev/score/util/TestingConstants.kt
+++ b/app/src/main/java/com/cornellappdev/score/util/TestingConstants.kt
@@ -68,6 +68,18 @@ val teamScore2 = TeamScore(
     totalScore = 23
 )
 
+val shortGameTeamScore1 = TeamScore(
+    team = team1,
+    scoresByPeriod = listOf(13, 14),
+    totalScore = 27
+)
+
+val shortGameTeamScore2 = TeamScore(
+    team = team2,
+    scoresByPeriod = listOf(7, 7),
+    totalScore = 14
+)
+
 val mediumGameTeamScore1 = TeamScore(
     team = team1,
     scoresByPeriod = listOf(13, 14, 6, 14, 13, 2),
@@ -90,6 +102,8 @@ val longGameTeamScore2 = TeamScore(
     totalScore = 47
 )
 val gameData = GameData(teamScores = Pair(teamScore1, teamScore2))
+
+val shortGameData = GameData(teamScores = shortGameTeamScore1 to shortGameTeamScore2)
 
 val mediumGameData = GameData(teamScores = mediumGameTeamScore1 to mediumGameTeamScore2)
 

--- a/app/src/main/java/com/cornellappdev/score/util/TestingConstants.kt
+++ b/app/src/main/java/com/cornellappdev/score/util/TestingConstants.kt
@@ -100,12 +100,14 @@ val longGameTeamScore2 = TeamScore(
     team = team1,
     scoresByPeriod = listOf(7, 7, 9, 0, 7, 7, 9, 0, 7, 2),
     totalScore = 47
+)
 
 val extraLongGameTeamScore1 = TeamScore(
     team = team1,
     scoresByPeriod = listOf(13, 14, 6, 14, 13, 2, 4, 6, 2, 2, 3, 4),
     totalScore = 54
 )
+
 val extraLongGameTeamScore2 = TeamScore(
     team = team1,
     scoresByPeriod = listOf(7, 7, 9, 0, 7, 7, 9, 0, 7, 2, 1, 1),


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->
<!-- Your title should be able to summarize what changes you’ve made in one sentence. For example: “Exclude staff from the check for follows”. For stacked PRs, please indicate clearly in the title where in the stack you are. For example: “[Eatery Refactor][4/5] Converted all files to MVP model” -->
## Overview
Fixes #80 and #66 
Also fixes small bug with the logic of coloring the winning team's total score green.
<!-- Summarize your changes here. -->
## Changes Made
- Fixed lacrosse icon
- Fixed border cutoffs by wrapping ScoreBox component in a Surface
- Fixed team name cutoff error by setting a max width of 70.dp (approximately how long "Cornell" is in the font size for > 4 data columns) to allow adequate space for both the team name column and all of the data columns (if there's < 4 data columns, then I allow the team name column to take up IntrinsicSize.Max to fill up empty space
- Fixed alignment issues by refactoring table to a Row of Columns structure as opposed to a Column of Rows.
- Added if-else statement in the total scores column so that the color is green if that team won
- Accounted for edge case where the number of data columns > 10, in which case the data columns become a LazyRow that scrolls between the fixed team name column and totals column
<!-- Include details of what your changes actually are and how it is intended to work. -->
## Test Coverage
- Wrote more test data for different game lengths (2, 4, 6, 10, 12 in total)
- appears correct in previews

## Screenshots (delete if not applicable)

<img width="515" height="409" alt="Screenshot 2025-09-21 at 7 16 27 PM" src="https://github.com/user-attachments/assets/27cd0f5e-6826-452f-a521-1f40b253aa08" />
